### PR TITLE
Add laravel APP_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Will build the client code, spin up the server in a docker instance with `http:/
 Next, you should generate a new application key for the production environment:
 
 ```shell
-docker exec -it server php artisan key:generate
+docker exec -it server php server/artisan key:generate
 ```
 
 And run the database migrations:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ docker-compose -f docker-compose-prod.yml up
 
 Will build the client code, spin up the server in a docker instance with `http://localhost:4000/` pointing to the client's index.html and built js/css.
 
+Next, you should generate a new application key for the production environment:
+
+```shell
+docker exec -it server php artisan key:generate
+```
+
+And run the database migrations:
+
+```shell
+docker exec -it server php server/artisan migrate
+```
+
 ## Configuration
 
 See the .env.example files in client and server directories.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,6 @@
 APP_NAME=fssk-laravel
 APP_ENV=local
-APP_KEY=
+APP_KEY=base64:YDoAdSONDVVUE9rejyUroF+RNeAyIeOX3jxlGItX8hQ=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost:4000


### PR DESCRIPTION
I realized when checking out a fresh copy that the an `APP_KEY` needed to be generated for the laravel `.env` file. Rather than making people do this every time, I figured it could just be added to the `.env.example`, so all development environments will be the same. I updated the readme to include instructions to generate a new key for production builds.