### PR TITLE
Production build improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ And run the database migrations:
 docker exec -it server php server/artisan migrate
 ```
 
+To eek out best performance, should also run `php server/artisan config:cache` and `php server/artisan route:cache`, and make sure `APP_DEBUG` is false.
+
 ## Configuration
 
 See the .env.example files in client and server directories.

--- a/deploy/server.docker
+++ b/deploy/server.docker
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y wget git zip postgresql postgresql-cont
 COPY ./deploy/vhost /etc/apache2/sites-enabled/000-default.conf
 COPY ./deploy/server-entrypoint.sh /server-entrypoint.sh
 
+COPY ./ /var/www
+
 RUN wget -q 'https://getcomposer.org/installer' -O - | php; \
     mv composer.phar /usr/local/bin/composer;
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -7,6 +7,7 @@ services:
     hostname: 'server'
     container_name: 'server'
     entrypoint: /server-entrypoint.sh
+    env_file: /server/.env
     command: 'apache2-foreground'
     ports:
       - '4000:80'
@@ -24,6 +25,7 @@ services:
       dockerfile: deploy/client.docker
     hostname: 'client'
     container_name: 'client'
+    env_file: /client/.env
     command: 'npm run build'
     volumes:
       - './client:/opt/src'

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -10,10 +10,6 @@ services:
     command: 'apache2-foreground'
     ports:
       - '4000:80'
-    volumes:
-      - './:/var/www'
-      - './deploy/server-entrypoint.sh:/server-entrypoint.sh'
-      - './deploy/php.ini:/usr/local/etc/php/php.ini'
     depends_on:
       - db
       - client

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -7,7 +7,7 @@ services:
     hostname: 'server'
     container_name: 'server'
     entrypoint: /server-entrypoint.sh
-    env_file: /server/.env
+    env_file: ./server/.env
     command: 'apache2-foreground'
     ports:
       - '4000:80'
@@ -25,7 +25,7 @@ services:
       dockerfile: deploy/client.docker
     hostname: 'client'
     container_name: 'client'
-    env_file: /client/.env
+    env_file: ./client/.env
     command: 'npm run build'
     volumes:
       - './client:/opt/src'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     hostname: 'server'
     container_name: 'server'
     entrypoint: /server-entrypoint.sh
+    env_file: /server/.env
     command: 'apache2-foreground'
     ports:
       - '4000:80'
@@ -27,6 +28,7 @@ services:
       dockerfile: deploy/client.docker
     hostname: 'client'
     container_name: 'client'
+    env_file: /client/.env
     command: 'npm start'
     ports:
       - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     hostname: 'server'
     container_name: 'server'
     entrypoint: /server-entrypoint.sh
-    env_file: /server/.env
+    env_file: ./server/.env
     command: 'apache2-foreground'
     ports:
       - '4000:80'
@@ -28,7 +28,7 @@ services:
       dockerfile: deploy/client.docker
     hostname: 'client'
     container_name: 'client'
-    env_file: /client/.env
+    env_file: ./client/.env
     command: 'npm start'
     ports:
       - '3000:3000'

--- a/server/app/Http/Controllers/HomeController.php
+++ b/server/app/Http/Controllers/HomeController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App;
+use File;
+
+class HomeController extends Controller
+{
+	public function index()
+	{
+		if (App::environment('local')) {
+			return view('welcome');
+		} else {
+			return File::get(public_path() . '/client/index.html');
+		}
+	}
+}

--- a/server/app/Http/Kernel.php
+++ b/server/app/Http/Kernel.php
@@ -28,13 +28,13 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\EncryptCookies::class,
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
+            // \App\Http\Middleware\EncryptCookies::class,
+            // \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            // \Illuminate\Session\Middleware\StartSession::class,
             // \Illuminate\Session\Middleware\AuthenticateSession::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\VerifyCsrfToken::class,
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            // \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            // \App\Http\Middleware\VerifyCsrfToken::class,
+            // \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
 
         'api' => [

--- a/server/routes/web.php
+++ b/server/routes/web.php
@@ -11,13 +11,6 @@
 |
 */
 
-if (App::environment('local')) {
-	Route::get('/', function () {
-		return view('welcome');
-	});
-} else {
-	//in production, route all web (aka not /api) calls to the root
-	Route::get('/{action}', function () {
-		return File::get(public_path() . '/client/index.html');
-	})->where('action', '(.*)');
-}
+//route all web (aka not /api) calls to the root
+Route::get('/{action}', 'HomeController@index')->where('action', '(.*)');
+


### PR DESCRIPTION
Improvements on performance and functionality of production builds. 

Performance of Laravel from a mounted volume in Docker is truly awful. Like 900ms response time from super simple API calls. In a production build, where the code is just copied directly into the docker container, and config/route caching is enabled, the same service calls are under 100ms.

I updated the server dockerfile so it copies the code into the container instead of mounting it as a volume. Also, to eek out best performance, I refactored the home page route to allow route caching to be enabled. Also fixed issue preventing sessions from working correctly when running in production mode.